### PR TITLE
add route to get the number of pending jobs (without claiming any)

### DIFF
--- a/web/backend.py
+++ b/web/backend.py
@@ -118,6 +118,18 @@ def main():
         sql_finish_job(unique_id, conversation_llm, conversation, source)
         return jsonify({"msg": "OK"})
 
+    '''
+    watchdog: if preshared secret matches, return the number
+    of sessions that have a pending question
+    '''
+    @app.route("/get_pending_count")
+    def get_pending_count():
+        secret = str(request.args.get("secret"))
+        if secret != preshared_secret:
+            abort(403)
+        ret = sql_get_pending_count()
+        return jsonify(ret)
+
     if __name__ == '__main__':
 
         bind_ip = os.environ.get('BIND_IP')

--- a/web/libsql.py
+++ b/web/libsql.py
@@ -130,6 +130,20 @@ def sql_claim_job() -> Dict:
     return ret
 
 
+def sql_get_pending_count() -> Dict:
+    conn = sqlite3.connect(sql_settings.get("db_path"))
+    curs = conn.cursor()
+    curs.execute('''
+        SELECT count(*) as cnt FROM session
+            WHERE state = 'question-queued' or state = 'processing-question';
+    ''')
+    res = curs.fetchone()
+    ret = {"count": res[0]}
+    conn.commit()
+    conn.close()
+    return ret
+
+
 def sql_finish_job(unique_id: str, conversation_llm: str, conversation: str, source: str):
     conn = sqlite3.connect(sql_settings.get("db_path"))
     curs = conn.cursor()


### PR DESCRIPTION
please pull :)

this changes only the backend.py running in docker. we need this to know if there are any pendings jobs for the on-demand-script.

-- Chris

