### PR TITLE
add rate limit and retry

### DIFF
--- a/scrapers/secrets_gh.json
+++ b/scrapers/secrets_gh.json
@@ -1,4 +1,5 @@
 {
   "github_token" : "YOUR_GITHUB_TOKEN_to_make_more_requests_per_hour_Otherwise_leave_blank",
-  "project_owner" : "YOUR_GITHUB_ACCOUNT"
+  "project_owner" : "YOUR_GITHUB_ACCOUNT",
+  "rate_limit_delay_sec" : 61
 }


### PR DESCRIPTION
# Changes Made

- Add rate_limit_delay_sec parameter to account for 60 requests per hour for anonymous user
- Add sleep and retry in case urlopen fails or the status of request is not 200