### PR TITLE
Add Docker-based deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Web frontend
+BASIC_AUTH_USER=user
+BASIC_AUTH_PASSWORD=password
+BIND_IP=0.0.0.0
+BIND_PORT=9001
+SERVER_PORT=8999
+
+# Shared secret between the web frontend and the RAG inference worker
+PRESHARED_SECRET=changeme
+
+# PostgreSQL
+PG_HOST=postgres
+PG_PORT=5432
+PG_DBNAME=ragdb
+PG_USER=rag
+PG_PASSWORD=rag
+
+# LLM endpoint (OpenAI-compatible chat-completion API)
+# Examples:
+#   OpenRouter:  https://openrouter.ai/api/v1/chat/completions
+#   Ollama:      http://host.docker.internal:11434/v1/chat/completions
+LLM_ENDPOINT=
+LLM_MODEL=
+LLM_API_KEY=
+
+# URL of the web frontend as seen by the RAG inference worker (internal Docker network)
+STUART_WEB_ENDPOINT=http://web:9001

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ log_ghissues/*.txt
 .venv
 
 .env
+
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
     * [Preparing and RAGging the documents](#preparing-and-ragging-the-documents)
     * [Running the chatbot on the command line](#running-the-chatbot-on-the-command-line)
     * [Running the chatbot as a web application](#running-the-chatbot-as-a-web-application)
+  * [Running with Docker](#running-with-docker)
+    * [Quick start](#quick-start)
+    * [Adding documents](#adding-documents)
+    * [CLI query inside Docker](#cli-query-inside-docker)
   * [Document scrapers (optional)](#document-scrapers-optional)
   * [FAQ](#faq)
     * [What about documents in other formats (.pdf, .docx, etc...)?](#what-about-documents-in-other-formats-pdf-docx-etc)
@@ -25,6 +29,7 @@
 
 **Changelog of this document**
 
+- 2026-05-15 added Docker section
 - 2026-02-01 updated for the major revision
 - 2024-07-07 expanded to include information about the new web frontend and add a few recommendations for custom deployments
 - 2024-03-27 added note about llama-cpp-python compile options
@@ -585,6 +590,133 @@ SQLite database (file `db/stuart.db`). It is recreated automatically at startup,
 
 > The files `docker-compose.yml`, `.env.example` and the directory `infrastructure` are specific
 > to the deployment at NOI Techpark.
+
+---
+## Running with Docker
+
+The repository ships with a `docker-compose.yml` that brings up all required services in one command:
+
+| Service | Description |
+|---------|-------------|
+| `postgres` | PostgreSQL with the pgvector extension (schema created automatically) |
+| `web` | Flask web frontend (Stuart UI) |
+| `rag` | Inference worker — polls the web frontend, runs embedding search and calls the LLM |
+| `rag-loader` | One-shot document loader, run on demand via a Docker Compose profile |
+
+> The `rag` image bakes the [bge-m3](https://huggingface.co/BAAI/bge-m3) embedding model (~2.2 GiB) into the image
+> at build time, so **no network download happens at container startup**. The first build will therefore take longer
+> and produce a ~10 GiB image.
+
+### Quick start
+
+**1. Clone the repository and create your `.env` file:**
+
+```shell
+git clone https://github.com/noi-techpark/stuart-chatbot
+cd stuart-chatbot
+cp .env.example .env
+```
+
+Open `.env` and fill in the required values:
+
+```shell
+# A secret string shared between the web frontend and the inference worker
+PRESHARED_SECRET=changeme
+
+# Your LLM endpoint, model name and API key
+# Examples:
+#   OpenRouter:  LLM_ENDPOINT=https://openrouter.ai/api/v1/chat/completions
+#   Ollama:      LLM_ENDPOINT=http://host.docker.internal:11434/v1/chat/completions
+LLM_ENDPOINT=https://openrouter.ai/api/v1/chat/completions
+LLM_MODEL=your-model-name
+LLM_API_KEY=your-api-key
+```
+
+All other values (Postgres credentials, ports, etc.) have sensible defaults already set in `.env.example`.
+
+**2. Build and start all services:**
+
+```shell
+docker compose up -d --build
+```
+
+The first build downloads and installs `sentence-transformers` and bakes the embedding model into the image.
+Expect it to take **10–20 minutes** depending on your connection and hardware.
+
+**3. Load the example documents into Postgres (first time only):**
+
+```shell
+docker compose --profile loader run --rm rag-loader
+```
+
+The loader is incremental — re-running it after adding new documents will only process the new files.
+
+**4. Open the web UI:**
+
+Navigate to [http://localhost:8999](http://localhost:8999). Each page load creates a new session.
+You can start asking questions straight away.
+
+### Adding documents
+
+To make Stuart answer questions about your own documents:
+
+**1. Drop your `.txt` or `.md` files into `data_example/`** (or any other `data_*/` directory):
+
+```shell
+cp my-document.md ~/stuart-chatbot/data_example/
+```
+
+> Files in other formats (PDF, DOCX, etc.) must first be converted to Markdown.
+> See [What about documents in other formats?](#what-about-documents-in-other-formats-pdf-docx-etc)
+
+**2. Re-run the loader** — it will only process the new files, skipping ones already in the database:
+
+```shell
+docker compose --profile loader run --rm rag-loader
+```
+
+The running `rag` container picks up the new vectors immediately on the next query — no restart needed.
+
+**To use a completely new directory**, make two small edits:
+
+- Add a volume mount in `docker-compose.yml` under the `rag-loader` service:
+
+```yaml
+volumes:
+  - ./my-docs:/usr/src/app/../my-docs:ro
+```
+
+- Add a `rag_dir` call in `rag/load.py`:
+
+```python
+rag_dir("../my-docs", tag="mydocs", chunk_len=5000, overlap_len=500, hard_limit=6000)
+```
+
+Then re-run the loader as above.
+
+**To delete documents from the database**, connect to Postgres and run a delete query:
+
+```shell
+docker compose exec postgres psql -U rag ragdb
+```
+
+```sql
+delete from ragdata where tag = 'example' and file_name = 'my-document.md';
+delete from ragdata where tag = 'example'; -- delete all chunks with a given tag
+truncate ragdata;                           -- delete everything (!)
+```
+
+### CLI query inside Docker
+
+You can also use Stuart interactively from the command line without leaving Docker:
+
+```shell
+docker compose exec rag python query.py
+```
+
+This drops you into the same interactive loop described in
+[Running the chatbot on the command line](#running-the-chatbot-on-the-command-line),
+using the already-running container with its pre-loaded model and database connection.
 
 ---
 ## Document scrapers (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${PG_USER}
+      POSTGRES_PASSWORD: ${PG_PASSWORD}
+      POSTGRES_DB: ${PG_DBNAME}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PG_USER} -d ${PG_DBNAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  web:
+    build:
+      context: ./web
+      dockerfile: infrastructure/docker/Dockerfile
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "${SERVER_PORT}:9001"
+    volumes:
+      - stuart-db:/usr/src/app/db/
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  rag:
+    build:
+      context: ./rag
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      PG_HOST: postgres
+    command: ["python", "backend_query.py"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      web:
+        condition: service_started
+
+  rag-loader:
+    build:
+      context: ./rag
+      dockerfile: Dockerfile
+    env_file: .env
+    environment:
+      PG_HOST: postgres
+    command: ["python", "load.py"]
+    volumes:
+      - ./data_example:/usr/src/app/../data_example:ro
+      - ./data_ghissues:/usr/src/app/../data_ghissues:ro
+      - ./data_readme:/usr/src/app/../data_readme:ro
+      - ./data_rt:/usr/src/app/../data_rt:ro
+      - ./data_wiki:/usr/src/app/../data_wiki:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles:
+      - loader
+
+volumes:
+  pgdata:
+  stuart-db:

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,0 +1,18 @@
+-- SPDX-FileCopyrightText: 2024 NOI Techpark <digital@noi.bz.it>
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS ragdata (
+    id          bigserial,
+    tag         text not null,
+    file_name   text not null,
+    start_pos   bigint,
+    end_pos     bigint,
+    ts          timestamp with time zone default now() not null,
+    file_body   text not null,
+    embedding   vector(1024) not null,
+    primary key(id),
+    unique(tag, file_name, start_pos, end_pos)
+);

--- a/rag/Dockerfile
+++ b/rag/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+WORKDIR /usr/src/app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN python -c "\
+from sentence_transformers import SentenceTransformer; \
+SentenceTransformer('BAAI/bge-m3', revision='5a212480c9a75bb651bcb894978ed409e4c47b82')"
+
+ENV TRANSFORMERS_OFFLINE=1 \
+    HF_DATASETS_OFFLINE=1
+
+COPY . .
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/rag/docker-entrypoint.sh
+++ b/rag/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Generates the JSON config files expected by the RAG Python scripts from environment variables,
+# then executes the container command. All variables except LLM_API_KEY are required:
+# the container will exit immediately with "unbound variable" if any of them are missing.
+set -eu
+
+# Generate secrets_pg.json from environment variables
+cat > /usr/src/app/secrets_pg.json <<EOF
+{
+  "host": "${PG_HOST}",
+  "port": "${PG_PORT}",
+  "dbname": "${PG_DBNAME}",
+  "user": "${PG_USER}",
+  "password": "${PG_PASSWORD}",
+  "connect_timeout": "${PG_CONNECT_TIMEOUT}"
+}
+EOF
+
+# Generate secrets_llm_endpoint.json from environment variables
+cat > /usr/src/app/secrets_llm_endpoint.json <<EOF
+{
+  "endpoint": "${LLM_ENDPOINT}",
+  "model": "${LLM_MODEL}",
+  "api_key": "${LLM_API_KEY-}"
+}
+EOF
+
+# Generate backend.json from environment variables
+cat > /usr/src/app/backend.json <<EOF
+{
+  "endpoint": "${STUART_WEB_ENDPOINT}",
+  "preshared_secret": "${PRESHARED_SECRET}"
+}
+EOF
+
+exec "$@"

--- a/rag/requirements.txt
+++ b/rag/requirements.txt
@@ -1,3 +1,6 @@
+# CPU-only PyTorch to avoid CUDA dependencies and reduce image size
+torch --index-url https://download.pytorch.org/whl/cpu
+
 psycopg2-binary==2.9.11
 sentence-transformers==2.6.0
 requests==2.32.5

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,6 @@
+# Subset of environment variables for standalone web development.
+# For full-stack deployment, see the root .env.example instead.
+
 BASIC_AUTH_USER=user
 BASIC_AUTH_PASSWORD=password
 


### PR DESCRIPTION
Docker Compose setup for running the full Stuart stack (PostgreSQL + web + RAG worker) containerized. This PR solves [this issue](https://github.com/noi-techpark/stuart-chatbot/issues/19).

Trade-off: The embedding model (`BAAI/bge-m3`, ~2.1 GiB) is baked into the RAG image for immediate startup without runtime downloads, I'd be happy to get feedback about this.

I tested it with OpenRouter and it works just fine as I couldn't test it with a local model.

